### PR TITLE
fix: change default service url to prod cluster

### DIFF
--- a/cfc/config.py
+++ b/cfc/config.py
@@ -10,7 +10,7 @@ from .auth import authenticate_keycloak
 
 class Config:  # pylint: disable=too-many-instance-attributes
     config_path: Path = Path()
-    service_url: str = "https://functions.cs-0a.contact-cloud.com"
+    service_url: str = "https://functions.cs-0b.contact-cloud.com"
     _conf: configparser.ConfigParser | None = None
     _client_id: str = ""
     _client_secret: str = ""


### PR DESCRIPTION
Default service url should point to the production cluster not the qa cluster.