### PR TITLE
Fix: Allow hyphens in environment variables

### DIFF
--- a/cfc/environment.py
+++ b/cfc/environment.py
@@ -13,7 +13,7 @@ from rich.table import Table
 from .config import config
 
 NAME_PATTERN = r"^[^\-\.][\w\-\.]+$"
-ENV_VARS_PATTERN = r"^([\w:.\/]+=[\w:.\/]+)(,[\w:.\/]+=[\w:.\/]+)*$"
+ENV_VARS_PATTERN = r"^([\w:.\/\-]+=[\w:.\/\-]+)(,[\w:.\/\-]+=[\w:.\/\-]+)*$"
 ENVIRONMENT_ENVVAR_NAME = "CFC_ENVIRONMENT"
 
 env_app = typer.Typer()
@@ -35,7 +35,7 @@ def tag_callback(name: str) -> str:
     return name_callback(name)
 
 
-def env_var_callback(env_vars: str) -> dict:
+def env_var_callback(env_vars: str) -> str:
     if not env_vars:
         return env_vars
     if not re.fullmatch(ENV_VARS_PATTERN, env_vars):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+import typer
+
+from cfc.environment import env_var_callback
+
+
+class TestEnvironment(TestCase):
+    def test_env_var_callback(self):
+        # Test valid input
+        env_var_callback("VAR1=VALUE1,VAR2=VALUE2")
+        env_var_callback("VAR1=abc-123:as123")
+        env_var_callback("VAR1=abc-123:as123,VAR2=abc-123:as123")
+        env_var_callback("VAR1=https://example.com,VAR2=abc-123:as123")
+
+        # test empty input
+        env_var_callback("")
+
+        # test invalid input
+        with self.assertRaises(typer.BadParameter):
+            env_var_callback("VAR1=VALUE1,VAR2=VALUE2,")
+        with self.assertRaises(typer.BadParameter):
+            env_var_callback("VAR1=VALUE1,VAR2=VALUE2,VAR3")
+        with self.assertRaises(typer.BadParameter):
+            env_var_callback("VAR1=VALUE1,VAR2=VALUE2,VAR3=VALUE3=")


### PR DESCRIPTION
It was not possible to add environment variables that contain hyphens ( -  ) in their value.
This is occasionally needed for certain API keys. (e.g. DeepL API-keys contain hyphen)

e.g. `cfc env deploy myenv --environment-variables "KEY=abc-123:fx"`

I fixed this by adjusting the regex.