### PR TITLE
fix: update environment variable pattern to be less restrictive

### DIFF
--- a/cfc/environment.py
+++ b/cfc/environment.py
@@ -13,7 +13,7 @@ from rich.table import Table
 from .config import config
 
 NAME_PATTERN = r"^[^\-\.][\w\-\.]+$"
-ENV_VARS_PATTERN = r"^([\w:.\/\-]+=[\w:.\/\-]+)(,[\w:.\/\-]+=[\w:.\/\-]+)*$"
+ENV_VARS_PATTERN = r"^([\w:.\/\-]+=[^=,\s]+)(,[\w:.\/\-]+=[^=,\s]+)*$"
 ENVIRONMENT_ENVVAR_NAME = "CFC_ENVIRONMENT"
 
 env_app = typer.Typer()

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -16,6 +16,12 @@ class TestEnvironment(TestCase):
         # test empty input
         env_var_callback("")
 
+        # test special characters in values
+        env_var_callback("VAR1=p@ssw0rd!")
+        env_var_callback("VAR1=value#1")
+        env_var_callback("VAR1=hello!,VAR2=world?")
+        env_var_callback("SECRET=abc$def%ghi^jkl&mno*pqr")
+
         # test invalid input
         with self.assertRaises(typer.BadParameter):
             env_var_callback("VAR1=VALUE1,VAR2=VALUE2,")
@@ -23,3 +29,7 @@ class TestEnvironment(TestCase):
             env_var_callback("VAR1=VALUE1,VAR2=VALUE2,VAR3")
         with self.assertRaises(typer.BadParameter):
             env_var_callback("VAR1=VALUE1,VAR2=VALUE2,VAR3=VALUE3=")
+        with self.assertRaises(typer.BadParameter):
+            env_var_callback("VAR1=value with spaces")
+        with self.assertRaises(typer.BadParameter):
+            env_var_callback("VAR1=val1,VAR2=val=2")


### PR DESCRIPTION
Update the environment variable pattern to allow special characters, except for "=",  "," and whitespaces